### PR TITLE
Release 1.1.1 -- update terraform-modules to 8.13.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ locals {
 }
 
 module "ecsservice" {
-  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=5.1.1"
+  source             = "github.com/silinternational/terraform-modules//aws/ecs/service-only?ref=8.13.0"
   cluster_id         = var.ecs_cluster_id
   service_name       = "adminer-${var.app_name}"
   service_env        = var.app_env


### PR DESCRIPTION
### Changed (non-breaking)
- Updated terraform-modules to 8.13.0 to update the AWS provider restriction