### PR TITLE
remove access key from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ example configuration:
 ```hcl
 provider "aws" {
   region     = var.aws_region
-  access_key = var.aws_access_key_id
-  secret_key = var.aws_secret_access_key
 }
 ```
 


### PR DESCRIPTION
[ITSE-702](https://support.gtis.sil.org/issue/ITSE-702) Detail out what would be needed in AWS to get rid of static tokens and move to Short-Length-of-Time tokens

### Removed
- Removed the AWS access key from the example code. It is not the best recommendation to use a static key.