### PR TITLE
add a "try" to fix failure during destroy while active

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "adminer_url" {
-  value = var.enable ? cloudflare_record.adminerdns[0].hostname : "(disabled)"
+  value = var.enable ? try(cloudflare_record.adminerdns[0].hostname, "") : "(disabled)"
 }


### PR DESCRIPTION
[ITSE-1251](https://support.gtis.sil.org/issue/ITSE-1251) terraform-aws-phpmyadmin #4: destroy with enable=true fails

### Fixed
- an invalid reference that occurs if the module is destroyed while `enable` is true.